### PR TITLE
[#6] Make Python short_timeout configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.1.2
+-----
+
+ - Make Python shell short_timeout configurable
+
 1.1.1
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.1.1'
+VERSION = '1.1.2'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/pythonshellbase.py
+++ b/src/crl/interactivesessions/shells/pythonshellbase.py
@@ -37,6 +37,10 @@ class PythonShellBase(Shell):
         LOGGER.log(_LOGLEVEL, "Exit from Python shell")
         self._send_input_line('exit()')
 
+    @classmethod
+    def set_short_timeout(cls, timeout):
+        cls.short_timeout = timeout
+
     def _single_command_no_output(self, cmd, timeout=10):
         LOGGER.log(_LOGLEVEL,
                    "(PythonShell) single_command_no_output send line: %s",

--- a/src/crl/interactivesessions/shells/timeouts.py
+++ b/src/crl/interactivesessions/shells/timeouts.py
@@ -1,6 +1,6 @@
 from crl.interactivesessions.shells.shell import DEFAULT_STATUS_TIMEOUT
 from crl.interactivesessions.shells.msgreader import MsgReader
-
+from crl.interactivesessions.shells.pythonshellbase import PythonShellBase
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
@@ -8,6 +8,8 @@ __copyright__ = 'Copyright (C) 2019, Nokia'
 class Timeouts(object):
     """Set common timeout for reading login banner and status code.
     """
+
+    _original_short_timeout = 10
 
     @staticmethod
     def set(timeout):
@@ -24,3 +26,14 @@ class Timeouts(object):
         """
         DEFAULT_STATUS_TIMEOUT.reset()
         MsgReader.reset_timeout()
+
+    @staticmethod
+    def set_python_short_timeout(timeout):
+        """Set timeout for short Python shell operations.
+        """
+        PythonShellBase.set_short_timeout(timeout)
+
+    def reset_python_short_timeout(self):
+        """Reset to default the timeout for short Python shell operations.
+        """
+        PythonShellBase.set_short_timeout(self._original_short_timeout)

--- a/tests/shells/test_timeouts.py
+++ b/tests/shells/test_timeouts.py
@@ -2,6 +2,8 @@ from contextlib import contextmanager
 from crl.interactivesessions.shells.timeouts import Timeouts
 from crl.interactivesessions.shells.shell import DEFAULT_STATUS_TIMEOUT
 from crl.interactivesessions.shells.msgreader import MsgReader
+from crl.interactivesessions.shells.rawpythonshell import RawPythonShell
+from crl.interactivesessions.shells.msgpythonshell import MsgPythonShell
 
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
@@ -31,3 +33,17 @@ def in_timeouts(timeout):
         yield timeout
     finally:
         t.reset()
+
+
+def test_python_short_timeout():
+    t = Timeouts()
+    assert_python_short_timeouts(10)
+    t.set_python_short_timeout(60)
+    assert_python_short_timeouts(60)
+    t.reset_python_short_timeout()
+    assert_python_short_timeouts(10)
+
+
+def assert_python_short_timeouts(timeout):
+    assert RawPythonShell.short_timeout == timeout
+    assert MsgPythonShell.short_timeout == timeout


### PR DESCRIPTION
Some times the current default short_timeout in Python shells is too
short for e.g. waiting prompt. To solve this problem, expose keywords
for configuring this timeout.