### PR TITLE
[#9] Add terminal leak correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.1.3
+-----
+
+ - Correct terminal leak in RemoteRunner
+
 1.1.2
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 GITHASH = ''
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,26 +1,59 @@
 import mock
+import pytest
 from crl.interactivesessions._process import _NoCommBackgroudProcess
 
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 
-class MockNoCommBackgroundProcess(_NoCommBackgroudProcess):
+@pytest.fixture
+def mock_terminalpools():
+    with mock.patch('crl.interactivesessions._process._TerminalPools',
+                    spec_set=True) as p:
+        proxies = mock.Mock()
+        p.return_value.get.return_value.proxies = proxies
+        proxies.daemon_popen.return_value = 'pid'
+        yield p
 
-    def _initialize_terminal(self):
-        self.terminal = mock.Mock()
-        self.terminalpools = mock.Mock()
-        self.proxies = mock.Mock()
-        self.proxies.daemon_popen.return_value = 'pid'
+
+class MockNoCommBackgroundProcess(_NoCommBackgroudProcess):
 
     @staticmethod
     def _nocall_comm():
         assert 0, 'Communicate called eventhough it should not'
 
 
-def test_nocommbackgroundprocess():
-    p = MockNoCommBackgroundProcess('cmd',
-                                    executable='executable',
-                                    shelldicts=[{'ExampleShell'}],
-                                    properties={})
+def test_nocommbackgroundprocess(mock_terminalpools):
+    p = create_mock_process()
+
     assert p.run() == 'pid'
+
+    assert_terminalpools(mock_terminalpools, mock_process=p)
+
+
+class DaemonError(Exception):
+    pass
+
+
+def test_nocommbackgroundprocess_raises(mock_terminalpools):
+    p = create_mock_process()
+    proxies = mock_terminalpools.return_value.get.return_value.proxies
+    proxies.daemon_popen.side_effect = DaemonError
+
+    with pytest.raises(DaemonError):
+        p.run()
+
+    assert_terminalpools(mock_terminalpools, mock_process=p)
+
+
+def create_mock_process():
+    return MockNoCommBackgroundProcess('cmd',
+                                       executable='executable',
+                                       shelldicts=[{'ExampleShell'}],
+                                       properties={})
+
+
+def assert_terminalpools(mock_terminalpools, mock_process):
+    tpools = mock_terminalpools.return_value
+    tpools.get.assert_called_once_with([set(['ExampleShell'])], {}, zone='background')
+    tpools.put.assert_called_once_with(mock_process.terminal)


### PR DESCRIPTION
The call execute_nohup_background_in_target did not put the terminal
back. This is corrected so that always after the call the terminal is
returned to the pool.