### PR TITLE
[#10] Convert string in set_python_short_timeout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.1.4
+-----
+
+ - Convert string to float in set_python_short_timeout
+
 1.1.3
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.1.3'
+VERSION = '1.1.4'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/timeouts.py
+++ b/src/crl/interactivesessions/shells/timeouts.py
@@ -31,7 +31,7 @@ class Timeouts(object):
     def set_python_short_timeout(timeout):
         """Set timeout for short Python shell operations.
         """
-        PythonShellBase.set_short_timeout(timeout)
+        PythonShellBase.set_short_timeout(float(timeout))
 
     def reset_python_short_timeout(self):
         """Reset to default the timeout for short Python shell operations.

--- a/tests/shells/test_timeouts.py
+++ b/tests/shells/test_timeouts.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import pytest
 from crl.interactivesessions.shells.timeouts import Timeouts
 from crl.interactivesessions.shells.shell import DEFAULT_STATUS_TIMEOUT
 from crl.interactivesessions.shells.msgreader import MsgReader
@@ -35,11 +36,15 @@ def in_timeouts(timeout):
         t.reset()
 
 
-def test_python_short_timeout():
+@pytest.mark.parametrize('timeout, expected', [
+    (60, 60.0),
+    ('60', 60.0),
+    (60.0, 60.0)])
+def test_python_short_timeout(timeout, expected):
     t = Timeouts()
     assert_python_short_timeouts(10)
-    t.set_python_short_timeout(60)
-    assert_python_short_timeouts(60)
+    t.set_python_short_timeout(timeout)
+    assert_python_short_timeouts(expected)
     t.reset_python_short_timeout()
     assert_python_short_timeouts(10)
 


### PR DESCRIPTION
Convert string to float in set_python_short_timeout to make keyword
calling easier from Robot Framework.