### PR TITLE
[#17] Do not use failed terminal of MsgPythonShell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,21 @@
 
 CHANGES
 =======
+
+1.2.1
+-----
+
+- Stop using terminal after fatal failure from MsgPythonShell
+
 1.2.0
 -----
 
 - Improved test coverage and added python 3 to setup
+
+1.1.7
+-----
+
+ - Stop using terminal after fatal failure from MsgPythonShell
 
 1.1.6
 -----

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,7 @@ include .coveragerc
 include .pylintrc
 include README.rst
 include .flake8
+include etc/docker-robottests
+include etc/docker_cmd
+include etc/Dockerfile
+include etc/sshd_config

--- a/etc/docker-robottests
+++ b/etc/docker-robottests
@@ -3,4 +3,4 @@ SCRIPT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
 docker build --rm -t test .
 docker run \
 -v ${SCRIPT_DIR}/..:/work \
---rm test \
+--rm test

--- a/robottests/targethosts.py
+++ b/robottests/targethosts.py
@@ -11,7 +11,6 @@ executed as root.
     Hosts HOST1 and HOST2 shall not share the same home directory.
 """
 
-
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 DICT__HOST1 = {'host': 'localhost', 'user': 'python2user', 'password': 'python2testing'}

--- a/robottests/test_remoterunner.robot
+++ b/robottests/test_remoterunner.robot
@@ -51,22 +51,18 @@ Get Pools Maxsize
     ${pool_obj}=     Get Library Instance  Pools
     [Return]    ${pool_obj.maxsize}
 
-
 Remove Filepath In Target
     [Arguments]  ${target}  ${path}
     RemoteRunner.Execute Command In Target    rm ${path}  target=${target}
-
 
 Remove Files Locally And In Target
     Run Process  rm  targetlocal  remotescriptfile
     Remove Filepath In Target  target1  ./targetlocal
     Remove Filepath In Target  target2  ./targetlocal
 
-
 Remove Directory In Target
     [Arguments]     ${target}   ${dir}
     RemoteRunner.Execute Command In Target  rm -rf ${dir}   target=${target}
-
 
 Set RemoteRunner Targets
     RemoteRunner.Set Target    shelldicts=${SHELLDICTS1}
@@ -78,13 +74,11 @@ Set RemoteRunner Targets
 Create Random File
     filehelper.Create Random File    targetlocal    100000
 
-
 Verify Run
     [Arguments]   ${ret}    ${expected_status}
     Should Be Equal As Integers    ${ret.status}    ${expected_status}
     Should Be Equal   ${ret.stdout}    out
     Should Be Equal   ${ret.stderr}    err
-
 
 Test Execute Nohup Background In Target
     [Arguments]  ${target}
@@ -96,13 +90,11 @@ Test Execute Nohup Background In Target
     ...             target=${target}
     Should Be Equal As Integers     ${ret.status}   0   ${ret}
 
-
 Test Execute Command In Target
     [Arguments]  ${target}
     ${ret}=    RemoteRunner.Execute Command In Target
     ...    ${COMMAND}    target=${target}
     Verify Run    ${ret}    0
-
 
 Test Execute Background Commands
     [Arguments]  ${target}
@@ -113,7 +105,6 @@ Test Execute Background Commands
     ${ret_from_wait}=    Remoterunner.Wait Background Execution
     ...    ${target}   t=1
     Should Be Equal    ${ret_from_wait}    ${ret}
-
 
 Test File Copying
     [Arguments]  ${target1}  ${target2}
@@ -142,7 +133,6 @@ Test Break Sessions Before Execute Command In Target
         Verify Run    ${ret}    0
      END
 
-
 Test Hang Sessions Before Execute Command In Target
     [Arguments]  ${target}
     RemoteRunner.Set Target Property    ${target}    prompt_timeout    1
@@ -152,7 +142,6 @@ Test Hang Sessions Before Execute Command In Target
         ...    target=${target}
         Verify Run    ${ret}    0
      END
-
 
 Test Get Proxy From Call
     [Arguments]  ${target}
@@ -164,7 +153,6 @@ Test Get Proxy From Call
     ${ret}=    Call Method    ${testproxy}   test   0
     Should Be Equal   ${ret.testid}    1
     Should Be Equal   ${ret.status}    0
-
 
 Test Get Proxy Object
     [Arguments]  ${target}  ${username}
@@ -320,24 +308,20 @@ Template Test Execute Command In Target
     target1
     target2
 
-
 Template Test Execute Background Commands
     [Template]  Test Execute Background Commands
     target1
     target2
-
 
 Template Test File Copying
     [Template]  Test File Copying
     target1  target2
     target2  target1
 
-
 Template Test Break Sessions Before Execute Command In Target
     [Template]  Test Break Sessions Before Execute Command In Target
     target1
     target2
-
 
 Template Test Hang Sessions Before Execute Command In Target
     [Template]  Test Hang Sessions Before Execute Command In Target
@@ -349,19 +333,16 @@ Template Test Get Proxy From Call
     target1
     target2
 
-
 Template Test Get Proxy Object
     [Template]  Test Get Proxy Object
     target1  ${HOST1.user}
     target2  ${HOST2.user}
    [Teardown]  RemoteRunner.Close
 
-
 Template Test Execute Nohup Background In Target
     [Template]  Test Execute Nohup Background In Target
     target1
     target2
-
 
 Templated Test Set Target Property
     [Template]  Test Set Target Property

--- a/robottests/test_remoterunner_and_remotescript.robot
+++ b/robottests/test_remoterunner_and_remotescript.robot
@@ -154,7 +154,6 @@ Compare Execute Background Command In Target
     # comparison with results which RemoteScript should ideally return
     # See https://github.com/nokia/crl-remotescript/issues/11
 
-
 Compare File Copying
     Create Random File
     [Arguments]  ${target1}  ${target2}
@@ -198,8 +197,8 @@ Compare File Copying
     Compare Results    ${runner2}    ${script2}
     Compare Results    ${runner3}    ${script3}
     [Teardown]  Remove Files Locally And In Target
-*** Test Cases ***
 
+*** Test Cases ***
 Template Compare File Copying
     [Template]  Compare File Copying
     target1  target2
@@ -209,7 +208,6 @@ Template Compare Execute Command In Target
     [Template]  Compare Execute Command In Target
     target1
     target2
-
 
 Template Compare Copy Directory To Target
     [Template]  Compare Copy Directory To Target

--- a/src/crl/interactivesessions/_filecopier.py
+++ b/src/crl/interactivesessions/_filecopier.py
@@ -395,7 +395,7 @@ class _LocalDirCopier(_FileCopier):
 
     def _copy_directory(self, source_dir, target):
         try:
-            oswalktuple = (next(os.walk(source_dir)))
+            oswalktuple = next(os.walk(source_dir))
             self._copy_directory_from_oswalktuple(oswalktuple, target)
         except StopIteration:
             pass
@@ -411,4 +411,5 @@ class _LocalDirCopier(_FileCopier):
             nexttarget = target.create_with_append(d)
             nexttarget.makedirs_if_needed(oct(0o777))
             self._copy_directory(os.path.join(root, d), nexttarget)
+
         target.chmod(self.mode)

--- a/src/crl/interactivesessions/_process.py
+++ b/src/crl/interactivesessions/_process.py
@@ -9,7 +9,6 @@ from .runnerexceptions import RemoteTimeout
 from .shells.remotemodules.compatibility import (
     to_string, to_bytes, py23_unic, unic_to_string)
 
-
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 LOGGER = logging.getLogger(__name__)

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/remoteimporter.py
+++ b/src/crl/interactivesessions/remoteimporter.py
@@ -4,7 +4,6 @@ import types
 import logging
 from crl.interactivesessions.RunnerHandler import exec_in_module
 
-
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 logger = logging.getLogger(__name__)

--- a/src/crl/interactivesessions/shells/msgpythonshell.py
+++ b/src/crl/interactivesessions/shells/msgpythonshell.py
@@ -8,7 +8,8 @@ from .remotemodules import servers
 from .modules import MainModule
 from .terminalclient import (
     TerminalClient,
-    TerminalClientError)
+    TerminalClientError,
+    TerminalClientFatalError)
 from .remotemodules.exceptions import FatalPythonError
 from .remotemodules.msgs import (
     ExecCommandRequest,
@@ -124,6 +125,9 @@ class MsgPythonShell(RawPythonShell):
         except FatalPythonError as e:
             LOGGER.debug(e)
             self._fatalerror = e
+        except TerminalClientFatalError as e:
+            self._fatalerror = FatalPythonError(e)
+            raise
         except (TimeoutError, TerminalClientError):
             raise
         except Exception as e:  # pylint: disable=broad-except

--- a/src/crl/interactivesessions/shells/remotemodules/msgs.py
+++ b/src/crl/interactivesessions/shells/remotemodules/msgs.py
@@ -91,7 +91,6 @@ class MsgBase(object):
         return True
 
     def serialize(self):
-        LOGGER.debug('==== MsgBase serialize starting')
         return b''.join(self._serialize_strings())
 
     def _serialize_strings(self):

--- a/src/crl/interactivesessions/shells/remotemodules/pythoncmdline.py
+++ b/src/crl/interactivesessions/shells/remotemodules/pythoncmdline.py
@@ -66,7 +66,6 @@ class PythonCmdline(object):
 
 
 def get_code_object(cmd, mode='exec'):
-    LOGGER.debug("===== get_code_object: cmd == %s", cmd)
     try:
         return compile(cmd, '', 'eval')
     except SyntaxError:

--- a/tests/shells/terminals/promptpythonserver.py
+++ b/tests/shells/terminals/promptpythonserver.py
@@ -49,6 +49,7 @@ class PromptPythonServer(LineServerBase, servers.PythonServer):
             ret = self.pythoncmdline.exec_command(cmd)
             return b'' if ret is None else to_bytes(repr(ret))
         except SystemExit:
+            LOGGER.debug('PromptPythonServer: Exiting')
             raise LineServerExit
         except Exception as e:  # pylint: disable=broad-except
             return str(ExecCommandErrorObj(e, cmd))

--- a/tests/shells/terminals/serverterminal.py
+++ b/tests/shells/terminals/serverterminal.py
@@ -182,6 +182,9 @@ class ServerProcess(object):
     def stop(self, client_inout):
         self._server.stop(client_inout)
 
+    def terminate(self):
+        self._process.terminate()
+
     @property
     def server(self):
         return self._server
@@ -243,6 +246,9 @@ class ServerTerminal(SpawnBase):
             LOGGER.info('ServerProcess.stop() is not called, forcing exit')
             self._serverprocess.stop(self._client_inout)
         self.join(timeout=3)
+
+    def terminate(self):
+        self._serverprocess.terminate()
 
     def join(self, timeout):
         self._serverprocess.join(timeout=timeout)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Copyright (C) 2019, Nokia
 
 [tox]
-envlist = py27, py36, py37, atests, docs, doctest, pylint
+envlist = py27, py36, py37, atests, docs, doctest, pylint, pylint3, docker-robottests
 
 [base]
 deps =
@@ -140,11 +140,13 @@ commands =
     robot --loglevel TRACE --exclude skip {posargs} {toxinidir}/robottests
 
 [testenv:robottests2]
+parallel_show_output = True
 deps = {[robotbase]deps}
 basepython = python2.7
 commands = {[robotbase]commands}
 
 [testenv:robottests3]
+parallel_show_output = True
 deps = {[robotbase]deps}
 basepython = python3.7
 commands = {[robotbase]commands}


### PR DESCRIPTION
Do not use failed terminal of MsgPythonShell in case it is clear that no
acknowledgements are received from the terminal. Retrying MsgPythonShell
terminal in such case may cause unnecessary delays in the recovery
process.