### PR TITLE
[#29] Fix remote PythonServer failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.2.2
+-----
+
+- Fix remote PythonServer failure in case stdout is not writable
+
 1.2.1
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/autorecoveringterminal.py
+++ b/src/crl/interactivesessions/autorecoveringterminal.py
@@ -150,17 +150,20 @@ class AutoRecoveringTerminal(object):
         self._prepare()
 
     def _retry(self, function, broken_exceptions):
+        exc = None
         for _ in range(self._max_tries):
             try:
                 return function()
             except broken_exceptions as e:
                 exc = e
-                LOGGER.debug('%s: %s\nBacktrace: \n%s',
-                             e.__class__.__name__, e,
-                             ''.join(traceback.format_list(
-                                 traceback.extract_tb(sys.exc_info()[2]))))
+                msg = '{cls}: {msg}\nTraceback:\n{tb}'.format(
+                    cls=e.__class__.__name__,
+                    msg=str(e),
+                    tb=''.join(traceback.format_list(
+                        traceback.extract_tb(sys.exc_info()[2]))))
+                LOGGER.debug("AutoRecoveringTerminal: _retry: exception msg = %s",
+                             msg)
                 time.sleep(self._sleep_between_tries)
-
         raise SessionInitializationFailed(exc)
 
     def _init_session(self):

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ changedir = {toxinidir}
 deps =
     crl.devutils
     docutils==0.14
+    more-itertools <= 5.0.0
 
 commands =
     crl create_docs -v
@@ -100,6 +101,7 @@ commands =
 changedir = {toxinidir}
 deps =
     crl.devutils
+    more-itertools <= 5.0.0
 commands =
     crl create_robotdocs -v
 
@@ -114,6 +116,7 @@ commands =
 changedir = {toxinidir}
 deps =
     {[testenv:docs]deps}
+    more-itertools <= 5.0.0
 
 commands =
     crl test --no-virtualenv {posargs}


### PR DESCRIPTION
In case stdout is not writable, PythonServer fails. This is now fixed so
that writability is first checked with select. Only after that write is
called but EGAIN error is handled.