### PR TITLE
[#35] Make sys.stdout blocking in remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 sudo: false
 dist: xenial
 language: python
-python:
-  - "2.7"
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - name: py27-pylint27
+      python: 2.7
+      env: TOXENV=py27,pylint27
+    - name: py36
+      python: 3.6
+      env: TOXENV=py36
+    - name: py37-pylint37-docs-doctest
+      python: 3.7
+      env: TOXENV=py37,pylint37,docs,doctest
+    - name: docker-robottests
+      python: 3.7
+      env: TOXENV=docker-robottests
 install:
-  - pip install tox-travis
+  - pip install tox
 script: tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.2.3
+-----
+
+- Set sys.stdout.fileno() blocking in remote.
+
 1.2.2
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.2.2'
+VERSION = '1.2.3'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/remotemodules/servercomm.py
+++ b/src/crl/interactivesessions/shells/remotemodules/servercomm.py
@@ -1,4 +1,3 @@
-import logging
 import time
 import sys
 import os
@@ -12,18 +11,11 @@ if 'chunkcomm' not in globals():
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 CHILD_MODULES = [chunkcomm, compatibility]
-LOGGER = logging.getLogger(__name__)
-
-
-class ServerCommError(Exception):
-    pass
 
 
 class ServerComm(chunkcomm.ChunkWriterBase, chunkcomm.ChunkReaderBase):
 
     _sleep_in_broken_systems = 0.00005
-    _write_tries = 3
-    _wait_for_writable = 10
 
     def __init__(self, infd, outfile):
         chunkcomm.ChunkReaderBase.__init__(self)
@@ -35,10 +27,20 @@ class ServerComm(chunkcomm.ChunkWriterBase, chunkcomm.ChunkReaderBase):
         self._write_meth = (self.outfile.buffer.write
                             if compatibility.PY3 else
                             self.outfile.write)
+        self._set_blocking_states()
+
+    def _set_blocking_states(self):
+        self._set_nonblocking_infd()
+        self._set_blocking_outfd()
 
     def _set_nonblocking_infd(self):
         fl = fcntl.fcntl(self.infd, fcntl.F_GETFL)
         fcntl.fcntl(self.infd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+    def _set_blocking_outfd(self):
+        outfd = self.outfile.fileno()
+        fl = fcntl.fcntl(outfd, fcntl.F_GETFL)
+        fcntl.fcntl(outfd, fcntl.F_SETFL, fl & ~os.O_NONBLOCK)
 
     def set_msgcaches(self, msgcaches):
         self._msgcaches = msgcaches
@@ -59,14 +61,7 @@ class ServerComm(chunkcomm.ChunkWriterBase, chunkcomm.ChunkReaderBase):
         return os.read(self.infd, n)
 
     def _write(self, s):
-        for _ in range(self._write_tries):
-            _, w, _ = select.select([], [self.outfile], [], self._wait_for_writable)
-            if w:
-                try:
-                    return self._write_meth(s)
-                except (OSError, IOError):
-                    pass
-        raise ServerCommError("stdout not writable")
+        self._write_meth(s)
 
     def _flush(self):
         self.outfile.flush()

--- a/tests/shells/remotemodules/test_servercomm.py
+++ b/tests/shells/remotemodules/test_servercomm.py
@@ -1,0 +1,27 @@
+import fcntl
+import os
+import pytest
+from crl.interactivesessions.shells.remotemodules.servercomm import ServerComm
+
+
+@pytest.fixture
+def infd(tmpdir):
+    infile = tmpdir.join('infile')
+    infile.write('content-of-infile')
+    with open(str(infile)) as f:
+        yield f.fileno()
+
+
+@pytest.fixture
+def outfile(tmpdir):
+    outfile = tmpdir.join('outfile')
+    with open(str(outfile), 'w') as f:
+        yield f
+
+
+def test_servercomm_blocking_states(infd, outfile):
+    s = ServerComm(infd, outfile)
+    infl = fcntl.fcntl(s.infd, fcntl.F_GETFL)
+    assert infl & os.O_NONBLOCK
+    outfl = fcntl.fcntl(s.outfile.fileno(), fcntl.F_GETFL)
+    assert not outfl & os.O_NONBLOCK

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Copyright (C) 2019, Nokia
 
 [tox]
-envlist = py27, py36, py37, atests, docs, doctest, pylint, pylint3, docker-robottests
+envlist = py{27,36,37}, atests, docs, doctest, pylint{27,37}, docker-robottests
 
 [base]
 deps =
@@ -57,12 +57,6 @@ commandd = {posargs:py.test --doctest-modules \
 addopts = --flake8 --cov-report xml
 norecursedirs = bin lib include
 
-[travis]
-python =
-	2.7: py27, pylint
-	3.6: py36, docker-robottests
-	3.7: py37, pylint3, docs
-
 [testenv:atests]
 deps =
     setuptools >= 35.0.1
@@ -73,26 +67,26 @@ commands = {posargs:pytest -vv\
            --junitxml=atests_junit.xml \
            {toxinidir}/atests}
 
-[testenv:pylint]
+[testenv:pylint27]
+basepython = python2.7
 deps =
     pylint < 2.0
     {[base2]deps}
 commands = pylint {posargs: --rcfile={toxinidir}/.pylintrc \
                     {toxinidir}/src/crl {toxinidir}/tests }
 
-[testenv:pylint3]
+[testenv:pylint37]
 basepython = python3.7
 deps =
     pylint
     {[base3]deps}
-commands = {[testenv:pylint]commands}
+commands = {[testenv:pylint27]commands}
 
 [testenv:docs]
+basepython = python3.7
 changedir = {toxinidir}
 deps =
     crl.devutils
-    docutils==0.14
-    more-itertools <= 5.0.0
 
 commands =
     crl create_docs -v
@@ -101,7 +95,6 @@ commands =
 changedir = {toxinidir}
 deps =
     crl.devutils
-    more-itertools <= 5.0.0
 commands =
     crl create_robotdocs -v
 
@@ -113,10 +106,10 @@ commands =
     robot --loglevel WARN {toxinidir}/stability_tests
 
 [testenv:test]
+basepython = python3.7
 changedir = {toxinidir}
 deps =
     {[testenv:docs]deps}
-    more-itertools <= 5.0.0
 
 commands =
     crl test --no-virtualenv {posargs}
@@ -153,4 +146,3 @@ parallel_show_output = True
 deps = {[robotbase]deps}
 basepython = python3.7
 commands = {[robotbase]commands}
-


### PR DESCRIPTION
If sys.stdout is in non-blocking state, then it is possible that writes
fail partially. This is corrected by setting sys.stdout.fileno() to
blocking state in the remote.