### PR TITLE
[#37] Acknowledge Server ID in start

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,15 @@
 CHANGES
 =======
 
+1.2.4
+-----
+
+- Acknowledge server ID reply in start of MsgPythonShell
+
 1.2.3
 -----
 
-- Set sys.stdout.fileno() blocking in remote.
+- Set sys.stdout.fileno() blocking in remote
 
 1.2.2
 -----

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.2.3'
+VERSION = '1.2.4'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/msgpythonshell.py
+++ b/src/crl/interactivesessions/shells/msgpythonshell.py
@@ -79,7 +79,7 @@ class MsgPythonShell(RawPythonShell):
         self._fatalerror = None
 
     def _get_server_id_in_start(self, timeout):
-        r = self._client.receive(timeout)
+        r = self._client.receive_and_send_ack(timeout)
         return r.server_id
 
     def exec_command(self, cmd, timeout=-1):

--- a/src/crl/interactivesessions/shells/terminalclient.py
+++ b/src/crl/interactivesessions/shells/terminalclient.py
@@ -110,7 +110,7 @@ class TerminalClient(MsgManagerBase):
         timer = Timer(timeout)
         for remaining_timeout in timer.remaining_timeouts():
             try:
-                r = self.receive(remaining_timeout)
+                r = self._receive(remaining_timeout)
             except TerminalClientError:
                 continue
             self._send_ack_if_needed(r)
@@ -134,7 +134,12 @@ class TerminalClient(MsgManagerBase):
     def send(self, msg):
         self._strcomm.write_str(self.serialize(msg))
 
-    def receive(self, timeout):
+    def receive_and_send_ack(self, timeout):
+        msg = self._receive(timeout)
+        self._send_ack_if_needed(msg)
+        return msg
+
+    def _receive(self, timeout):
         self._terminalcomm.set_timeout(timeout)
         with self._client_exception_wrap():
             return self.deserialize(self._strcomm.read_str())

--- a/tests/shells/conftest.py
+++ b/tests/shells/conftest.py
@@ -1,6 +1,18 @@
+from contextlib import contextmanager
+from collections import namedtuple
+import mock
 import pytest
 from crl.interactivesessions.shells.bashshell import BashShell
 from crl.interactivesessions.shells.shell import DEFAULT_STATUS_TIMEOUT
+from crl.interactivesessions.shells.msgpythonshell import MsgPythonShell
+from crl.interactivesessions.shells.terminalclient import TerminalClient
+from crl.interactivesessions.shells.remotemodules.msgmanager import (
+    StrComm,
+    Retry)
+
+from .loststrcomm import (
+    LostStrComm,
+    CustomTerminalComm)
 from .bashterminalshell import BashTerminalShell
 from .statuscodeverifier import StatusCodeVerifier
 
@@ -51,3 +63,142 @@ def statuscodeverifier(bash_shell_with_terminal, bash_terminal, status_timeout):
     return StatusCodeVerifier(bash_shell_with_terminal=bash_shell_with_terminal,
                               bash_terminal=bash_terminal,
                               timeout=status_timeout)
+
+
+@pytest.fixture
+def msgpythonshell(normal_pythonterminal):
+    with msgpythonshell_context(normal_pythonterminal) as m:
+        yield m
+
+
+@pytest.fixture
+def shortretry_msgpythonshell(retry_shellcontext):
+    with retry_shellcontext(Retry(tries=20, interval=0.4, timeout=0.5)) as s:
+        yield s
+
+
+@pytest.fixture
+def terminate_msgpythonshell(retry_shellcontext, normal_pythonterminal):
+    with retry_shellcontext(Retry(tries=3, interval=0.4, timeout=0.5)) as s:
+        try:
+            yield s
+        finally:
+            normal_pythonterminal.terminate()
+
+# pylint: disable=unused-argument
+@pytest.fixture
+def retry_shellcontext(mock_strcomm, simple_retry_shellcontext):
+    return simple_retry_shellcontext
+
+
+@pytest.fixture
+def simple_retry_shellcontext(normal_pythonterminal):
+    @contextmanager
+    def ctx(retry):
+        try:
+            MsgPythonShell.set_retry(retry)
+            with msgpythonshell_context(normal_pythonterminal) as m:
+                yield m
+        finally:
+            MsgPythonShell.reset_retry()
+
+    return ctx
+
+
+@pytest.fixture
+def client_rubbish_msgpythonshell(client_rubbish_pythonterminal_ctx):
+    with msgpythonshell_context(client_rubbish_pythonterminal_ctx.pythonterminal) as m:
+        yield m
+
+
+@pytest.fixture
+def server_rubbish_msgpythonshell(server_rubbish_pythonterminal_ctx):
+    with msgpythonshell_context(server_rubbish_pythonterminal_ctx.pythonterminal) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_strcomm(request):
+    lst = LostStrComm(**request.param)
+
+    def strcomm_fact(*args, **kwargs):
+        s = StrComm(*args, **kwargs)
+        lst.set_strcomm(s)
+        return lst
+
+    with customterminalcomm_context():
+        with mock.patch('crl.interactivesessions.shells.'
+                        'remotemodules.msgmanager.StrComm') as p:
+            p.side_effect = strcomm_fact
+            yield lst
+
+
+@contextmanager
+def customterminalcomm_context():
+    with mock.patch('crl.interactivesessions.shells.'
+                    'terminalclient.TerminalComm',
+                    side_effect=CustomTerminalComm) as p:
+        yield p
+
+
+class ShellContext(namedtuple('ShellContext', ['shell', 'context'])):
+    pass
+
+
+@pytest.fixture
+def client_rubbish_pythonterminal_ctx(rubbish_context, request):
+    with rubbish_context['client'] as ctx:
+        yield ctx
+
+
+@pytest.fixture
+def server_rubbish_pythonterminal_ctx(rubbish_context, request):
+    with rubbish_context['server'] as ctx:
+        yield ctx
+
+
+@pytest.fixture
+def chunk_msgpythonshell(chunk_pythonterminal_ctx):
+    with msgpythonshell_context(chunk_pythonterminal_ctx.pythonterminal) as m:
+        yield m
+
+
+class CustomTerminalClient(TerminalClient):
+    def __init__(self):
+        super(CustomTerminalClient, self).__init__()
+        self.received_msgs = []
+
+    def _receive(self, timeout):
+        msg = super(CustomTerminalClient, self)._receive(timeout)
+        self.received_msgs.append(msg)
+        return msg
+
+
+@pytest.fixture
+def customterminalclient():
+    c = CustomTerminalClient()
+    with mock.patch('crl.interactivesessions.shells.msgpythonshell.TerminalClient',
+                    spec_set=True) as p:
+        p.return_value = c
+        yield c
+
+
+@pytest.fixture
+def custommsgpythonshell(customterminalclient, simple_retry_shellcontext):
+    with simple_retry_shellcontext(Retry(tries=50, interval=0.01, timeout=0.5)) as s:
+        yield s
+
+
+@contextmanager
+def msgpythonshell_context(terminal):
+    m = MsgPythonShell()
+    m.set_terminal(terminal)
+    m.delaybeforesend = 1
+    m.start()
+    assert m.delaybeforesend == 0
+    try:
+        yield m
+    finally:
+        m.exit()
+        assert m.delaybeforesend == 1
+        terminal.join(timeout=3)

--- a/tests/shells/test_msgpythonshell.py
+++ b/tests/shells/test_msgpythonshell.py
@@ -1,23 +1,16 @@
 import sys
-from contextlib import contextmanager
-from collections import namedtuple
+import time
 from io import StringIO
-import mock
 import pytest
 import pexpect
 from crl.interactivesessions.shells.msgpythonshell import MsgPythonShell
 from crl.interactivesessions.shells.terminalclient import (
     TerminalClientError,
     TerminalClientFatalError)
-from crl.interactivesessions.shells.remotemodules.msgmanager import (
-    StrComm,
-    Retry)
 from crl.interactivesessions.shells.remotemodules.compatibility import (
     PY3,
     to_bytes)
-from .loststrcomm import (
-    LostStrComm,
-    CustomTerminalComm)
+from crl.interactivesessions.shells.remotemodules.msgs import ServerIdReply
 
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
@@ -27,126 +20,6 @@ __copyright__ = 'Copyright (C) 2019, Nokia'
 @pytest.fixture(autouse=True)
 def mock_term_functions_in_msgpythonshell(mock_term_functions):
     pass
-
-
-@pytest.fixture
-def msgpythonshell(normal_pythonterminal):
-    with msgpythonshell_context(normal_pythonterminal) as m:
-        yield m
-
-
-@pytest.fixture
-def shortretry_msgpythonshell(retry_shellcontext):
-    with retry_shellcontext(Retry(tries=20, interval=0.4, timeout=0.5)) as s:
-        yield s
-
-
-@pytest.fixture
-def terminate_msgpythonshell(retry_shellcontext, normal_pythonterminal):
-    with retry_shellcontext(Retry(tries=3, interval=0.4, timeout=0.5)) as s:
-        try:
-            yield s
-        finally:
-            normal_pythonterminal.terminate()
-
-
-@pytest.fixture
-def retry_shellcontext(mock_strcomm, normal_pythonterminal):
-    @contextmanager
-    def ctx(retry):
-        try:
-            MsgPythonShell.set_retry(retry)
-            with msgpythonshell_context(normal_pythonterminal) as m:
-                yield m
-        finally:
-            MsgPythonShell.reset_retry()
-
-    return ctx
-
-
-@pytest.fixture
-def client_rubbish_msgpythonshell(client_rubbish_pythonterminal_ctx):
-    with msgpythonshell_context(client_rubbish_pythonterminal_ctx.pythonterminal) as m:
-        yield m
-
-
-@pytest.fixture
-def server_rubbish_msgpythonshell(server_rubbish_pythonterminal_ctx):
-    with msgpythonshell_context(server_rubbish_pythonterminal_ctx.pythonterminal) as m:
-        yield m
-
-
-def corrupt(start, s):
-    return s[:start] + len(s) * b'x'
-
-
-def precorrupt(s):
-    return len(s) * b'x' + s
-
-
-def postcorrupt(s):
-    return s + len(s) * b'x'
-
-
-@pytest.fixture
-def mock_strcomm(request):
-    lst = LostStrComm(**request.param)
-
-    def strcomm_fact(*args, **kwargs):
-        s = StrComm(*args, **kwargs)
-        lst.set_strcomm(s)
-        return lst
-
-    with customterminalcomm_context():
-        with mock.patch('crl.interactivesessions.shells.'
-                        'remotemodules.msgmanager.StrComm') as p:
-            p.side_effect = strcomm_fact
-            yield lst
-
-
-@contextmanager
-def customterminalcomm_context():
-    with mock.patch('crl.interactivesessions.shells.'
-                    'terminalclient.TerminalComm',
-                    side_effect=CustomTerminalComm) as p:
-        yield p
-
-
-class ShellContext(namedtuple('ShellContext', ['shell', 'context'])):
-    pass
-
-
-@pytest.fixture
-def client_rubbish_pythonterminal_ctx(rubbish_context, request):
-    with rubbish_context['client'] as ctx:
-        yield ctx
-
-
-@pytest.fixture
-def server_rubbish_pythonterminal_ctx(rubbish_context, request):
-    with rubbish_context['server'] as ctx:
-        yield ctx
-
-
-@pytest.fixture
-def chunk_msgpythonshell(chunk_pythonterminal_ctx):
-    with msgpythonshell_context(chunk_pythonterminal_ctx.pythonterminal) as m:
-        yield m
-
-
-@contextmanager
-def msgpythonshell_context(terminal):
-    m = MsgPythonShell()
-    m.set_terminal(terminal)
-    m.delaybeforesend = 1
-    m.start()
-    assert m.delaybeforesend == 0
-    try:
-        yield m
-    finally:
-        m.exit()
-        assert m.delaybeforesend == 1
-        terminal.join(timeout=3)
 
 
 def test_exec_command_success(msgpythonshell):
@@ -192,6 +65,18 @@ def some_lost_strcomm():
         {'probability_of_lost': '1', 'modifier': postcorrupt}], indirect=True)
 
 
+def corrupt(start, s):
+    return s[:start] + len(s) * b'x'
+
+
+def precorrupt(s):
+    return len(s) * b'x' + s
+
+
+def postcorrupt(s):
+    return s + len(s) * b'x'
+
+
 @some_lost_strcomm()
 def test_exec_command_lostmsg(mock_strcomm, shortretry_msgpythonshell):
     shell = shortretry_msgpythonshell
@@ -231,6 +116,15 @@ def test_exec_command_timeout(mock_strcomm, shortretry_msgpythonshell):
             shortretry_msgpythonshell.exec_command('time.sleep(0.5)', timeout=0.1)
 
     assert 'Timeout' in str(excinfo.value)
+
+
+def test_server_id_received_only_once(custommsgpythonshell, customterminalclient):
+    shell = custommsgpythonshell
+    time.sleep(0.05)
+    shell.exec_command("'exec-content'")
+    serveridreplies = [m for m in customterminalclient.received_msgs
+                       if isinstance(m, ServerIdReply)]
+    assert len(serveridreplies) == 1
 
 
 def test_msgpythonshell_noattrs():


### PR DESCRIPTION
Currently the server ID received in the start of MsgPythonShell is not
acknowledged in start which may trigger the server to resend the server
ID reply.