### PR TITLE
[#27] Correct BashShell banner reading

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -242,7 +242,7 @@ notes=FIXME,XXX,TODO
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=5
 
 # Ignore comments when computing similarities.
 ignore-comments=yes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ CHANGES
 =======
 
 
+1.2.8
+-----
+
+- Fix BashShell banner reading error in slow shells by adding banner_timeout
+  keyword argument
+
+- Fix hanging of the start in case in case BashShell value of tty_echo is True
+  while in reality the terminal echo is off
+
 1.2.7
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
-VERSION = '1.2.7'
+VERSION = '1.2.8'
 GITHASH = ''
 
 

--- a/tests/shells/conftest.py
+++ b/tests/shells/conftest.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from collections import namedtuple
 import mock
 import pytest
+from crl.interactivesessions import InteractiveSession
 from crl.interactivesessions.shells.bashshell import BashShell
 from crl.interactivesessions.shells.shell import DEFAULT_STATUS_TIMEOUT
 from crl.interactivesessions.shells.msgpythonshell import MsgPythonShell
@@ -15,6 +16,8 @@ from .loststrcomm import (
     CustomTerminalComm)
 from .bashterminalshell import BashTerminalShell
 from .statuscodeverifier import StatusCodeVerifier
+from .mockspawn import MockSpawn
+from .interpreter import State
 
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
@@ -227,3 +230,15 @@ def msgpythonshell_context(terminal):
         m.exit()
         assert m.delaybeforesend == 1
         terminal.join(timeout=3)
+
+
+@pytest.fixture
+def mockspawn(monkeypatch):
+    monkeypatch.setattr(InteractiveSession.pexpect, 'spawn', MockSpawn)
+
+
+@pytest.fixture
+def mockspawn_state():
+    state = State()
+    MockSpawn.set_state(state)
+    return state

--- a/tests/shells/interpreter.py
+++ b/tests/shells/interpreter.py
@@ -1,0 +1,173 @@
+"""Shell command line emulator base
+"""
+import logging
+import abc
+from collections import namedtuple
+import six
+
+
+__copyright__ = 'Copyright (C) 2019, Nokia'
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Interpreter(object):
+    def __init__(self, handlers, state):
+        self._responses = Responses()
+        self._state = state
+        self._handlers = []
+        self._line = b''
+        self._set_handlers(handlers)
+
+    def __str__(self):
+        return 'responses: {responses}, state={state}, line={line}'.format(
+            responses=self._responses,
+            state=self._state,
+            line=self._line)
+
+    def _set_handlers(self, handlers):
+        for h in handlers:
+            h.set_state(self._state)
+            self._handlers.append(h)
+
+    def read(self, timeout):
+        ret = b''
+        for r in self._try_to_get_responses(timeout):
+            ret += r.response
+        return ret
+
+    def _try_to_get_responses(self, timeout):
+        try:
+            return self._responses.get_responses(timeout)
+        except ResponsesTimeout:
+            raise InterpreterTimeout
+
+    def write(self, s):
+        for line in self._lines(s):
+            self._responses.add_responses(self._responses_for_line(line))
+
+    def _lines(self, s):
+        for c in self._bytes_gen(s):
+            self._line += c
+            if c == b'\n':
+                yield self._line
+                self._line = b''
+
+    @staticmethod
+    def _bytes_gen(s):
+        for i in six.moves.range(len(s)):
+            yield s[i:i + 1]
+
+    def _responses_for_line(self, line):
+        for h in self._handlers:
+            try:
+                for r in h.get_responses(line):
+                    yield r
+                break
+            except HandlerNotMatching:
+                continue
+
+
+class InterpreterTimeout(Exception):
+    pass
+
+
+class State(object):
+    def __init__(self):
+        self.__dict__['_state'] = {}
+
+    def __getattr__(self, name):
+        try:
+            return self._state[name]
+        except KeyError:
+            raise StateAttributeError('No such attribute: {}'.format(name))
+
+    def __setattr__(self, name, value):
+        self._state[name] = value
+
+    def __str__(self):
+        return str(self._state)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class StateAttributeError(AttributeError):
+    pass
+
+
+@six.add_metaclass(abc.ABCMeta)
+class HandlerBase(object):
+    """Abstract class for :class:`.Interpreter` line handlers.
+    """
+    def __init__(self):
+        self._state = None
+
+    def set_state(self, state):
+        self._state = state
+
+    def get_responses(self, line):
+        """Get :class:`.Response` instance non empty iterable list or iterator
+        in case.
+
+        Raises: :class:`.HandlerNotMatching` in case no match.
+        """
+
+
+class HandlerNotMatching(Exception):
+    pass
+
+
+class Responses(object):
+    def __init__(self):
+        self._responses = []
+        self._current_time = 0
+
+    def add_responses(self, responses):
+        for r in responses:
+            self._responses.append(r.create_with_start(self._next_free_time))
+
+    @property
+    def _next_free_time(self):
+        return self._responses[-1].response_time if self._responses else 0
+
+    def get_responses(self, timeout):
+        responses = [r for r in self._responses_gen(timeout)]
+        if not responses:
+            raise ResponsesTimeout
+        return responses
+
+    def _responses_gen(self, timeout):
+        # Side effect: This generator updates time and removes yielded
+        # (consumed) responses
+        expires_at = self._current_time + timeout
+        for r in list(self._responses):
+            if r.response_time > expires_at:
+                break
+            self._current_time = r.response_time
+            self._responses.pop(0)
+            yield r
+
+    def __str__(self):
+        return 'responses: {responses}, time: {time}'.format(responses=self._responses,
+                                                             time=self._current_time)
+
+
+class ResponsesTimeout(Exception):
+    pass
+
+
+class Response(namedtuple('Response', ['response', 'latency', 'interpretation_start'])):
+
+    @property
+    def response_time(self):
+        return self.interpretation_start + self.latency
+
+    @classmethod
+    def create(cls, response, latency=0):
+        return cls(response=response, latency=latency, interpretation_start=0)
+
+    def create_with_start(self, interpretation_start):
+        kwargs = self._asdict()
+        kwargs['interpretation_start'] = interpretation_start
+        return Response(**kwargs)

--- a/tests/shells/mockspawn.py
+++ b/tests/shells/mockspawn.py
@@ -1,0 +1,91 @@
+import logging
+from pexpect.spawnbase import (
+    SpawnBase,
+    TIMEOUT)
+from crl.interactivesessions.shells.remotemodules.chunkcomm import SharedBytesIO
+from .interpreter import (
+    Interpreter,
+    InterpreterTimeout)
+
+__copyright__ = 'Copyright (C) 2019, Nokia'
+
+
+class Default(object):
+    pass
+
+
+DEFAULT = Default()
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MockSpawn(SpawnBase):
+
+    _handlers = None
+    _state = None
+
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 command,
+                 args=None,
+                 timeout=DEFAULT,
+                 maxread=DEFAULT,
+                 searchwindowsize=DEFAULT,
+                 logfile=DEFAULT,
+                 env=None,
+                 ignore_sighup=False,
+                 encoding=DEFAULT,
+                 codec_errors=DEFAULT):
+        super(MockSpawn, self).__init__(**self._get_kwargs(
+            timeout=timeout,
+            maxread=maxread,
+            searchwindowsize=searchwindowsize,
+            logfile=logfile,
+            encoding=encoding,
+            codec_errors=codec_errors))
+        self._state.env = {} if env is None else env
+        self._state.ignore_sighup = ignore_sighup
+        self._interpreter = Interpreter(self._handlers, self._state)
+        self._io = SharedBytesIO()
+        self.sendline(command if args is None else ' '.join([command] + args))
+
+    @staticmethod
+    def _get_kwargs(**kwargs):
+        return {n: v for n, v in kwargs.items() if v != DEFAULT}
+
+    def __str__(self):
+        return 'interpreter={interpreter}, readable={readable}, buf={buf}'.format(
+            interpreter=self._interpreter,
+            readable=self._io.readable_size,
+            buf=str(self._io.getvalue()))
+
+    def read_nonblocking(self, size=1, timeout=None):
+        LOGGER.debug('read_nonblocking called with size=%s, timeout=%s', size, timeout)
+        if not self._io.readable_size:
+            self._io.write(self._try_to_read(timeout))
+
+        ret = self._io.read(min(size, self._io.readable_size))
+        LOGGER.debug('read_nonblocking return %s', ret)
+        return ret
+
+    def _try_to_read(self, timeout):
+        try:
+            return self._interpreter.read(timeout)
+        except InterpreterTimeout:
+            raise TIMEOUT('Timeout exceeded')
+
+    def send(self, s=''):
+        LOGGER.debug('send called with %s', s)
+        b = self._encoder.encode(self._coerce_send_string(s), final=False)
+        self._interpreter.write(b)
+
+    def sendline(self, s=''):
+        return self.send(self._coerce_send_string(s) + b'\n')
+
+    @classmethod
+    def set_handlers(cls, handlers):
+        cls._handlers = handlers
+
+    @classmethod
+    def set_state(cls, state):
+        cls._state = state

--- a/tests/shells/test_bashshell.py
+++ b/tests/shells/test_bashshell.py
@@ -1,4 +1,130 @@
+import logging
+import os
+import pytest
+from crl.interactivesessions.InteractiveSession import InteractiveSession
+from crl.interactivesessions.shells.bashshell import (
+    BashShell,
+    BashShellTypeError)
+from crl.interactivesessions.shells.remotemodules.compatibility import to_bytes
+from .mockspawn import MockSpawn
+from .interpreter import (
+    HandlerBase,
+    HandlerNotMatching,
+    Response)
+
+
 __copyright__ = 'Copyright (C) 2019, Nokia'
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SlowBannerHandler(HandlerBase):
+
+    _initial_prompt = b'initial-prompt'
+    _responses = [Response.create(b'Banner line 1\n'),
+                  Response.create(b'Banner line 2\n', latency=1),
+                  Response.create(_initial_prompt)]
+
+    def get_responses(self, line):
+        path = line.split()[0]
+        if os.path.split(path)[-1] != b'bash':
+            raise HandlerNotMatching
+
+        self._state.prompt = self.initial_prompt
+        return self._responses
+
+    @property
+    def initial_prompt(self):
+        return self._initial_prompt
+
+    @property
+    def expected_banner(self):
+        return b''.join([r.response for r in self._responses])
+
+
+class EmptyResponseHandler(HandlerBase):
+    def get_responses(self, line):
+        for r in self._get_responses(line):
+            p = Response.create(
+                self._echo_line(line) + r.response + self._state.prompt)
+            LOGGER.debug('Response: %s', p.response)
+            yield p
+
+    def _echo_line(self, line):
+        return line if self._state.tty_echo else b''
+
+    @staticmethod
+    def _get_responses(line):  # pylint: disable=unused-argument
+        LOGGER.debug('Creating empty response')
+        return [Response.create(b'')]
+
+
+class EchoHandler(EmptyResponseHandler):
+
+    def _get_responses(self, line):
+        response = b''
+        for cmd in line.split(b';'):
+            tokens = cmd.split()
+            if tokens[0] != b'echo':
+                raise HandlerNotMatching
+            response += self._get_echo_from_tokens(tokens)
+        LOGGER.debug('Creating echo response')
+        yield Response.create(response)
+
+    @staticmethod
+    def _get_echo_from_tokens(tokens):
+        return tokens[-1] if tokens[1] == b'-n' else tokens[-1] + b'\n'
+
+
+class SttyEchoHandler(EmptyResponseHandler):
+
+    _echo_map = {b'echo': True, b'-echo': False}
+
+    def _get_responses(self, line):
+        if not line.startswith(b'stty '):
+            raise HandlerNotMatching
+        for token in line.split():
+            if token in self._echo_map:
+                self._state.tty_echo = self._echo_map[token]
+                LOGGER.debug('tty_echo set to %s', self._state.tty_echo)
+                return [Response.create(b'')]
+
+        raise HandlerNotMatching
+
+
+@pytest.fixture(params=[True, False])
+def echo_in_state(mockspawn_state, request):
+    mockspawn_state.tty_echo = request.param
+
+
+@pytest.fixture
+def slowbanner_handler():
+    slow = SlowBannerHandler()
+    MockSpawn.set_handlers([slow,
+                            EchoHandler(),
+                            SttyEchoHandler(),
+                            EmptyResponseHandler()])
+    return slow
+
+
+@pytest.mark.usefixtures('mockspawn', 'echo_in_state')
+@pytest.mark.parametrize('echo_in_init', [True, False])
+def test_bash_slow_banner(slowbanner_handler, echo_in_init):
+    i = InteractiveSession()
+    banner = i.spawn(BashShell(tty_echo=echo_in_init, banner_timeout=2))
+    assert to_bytes(banner).startswith(slowbanner_handler.expected_banner)
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'wrong': 1, 'banner_timeout': 2},
+    {'banner_timeout': 1, 'wrong': 2}])
+def test_bash_kwargs_not_accepted(kwargs):
+    with pytest.raises(BashShellTypeError) as excinfo:
+        BashShell(**kwargs)
+
+    expected = "BashShell() got an unexpected keyword argument 'wrong'"
+    assert str(excinfo.value) == expected
 
 
 def test_get_status_code(statuscodeverifier):

--- a/tests/shells/test_shells.py
+++ b/tests/shells/test_shells.py
@@ -44,6 +44,7 @@ class MockShell(MockBaseCls):
         super(MockShell, self).__init__(Shell, dir(BashShell),
                                         *args, **kwargs)
         self.tty_echo = False
+        self._terminal = mock.Mock()
 
 
 class MockBash(MockBaseCls):

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ commands =
     crl create_docs -v
 
 [testenv:docker-robottests]
+basepython = python3.7
 changedir = {toxinidir}/docker-robottests-targets
 deps = tox
 setenv =


### PR DESCRIPTION
- Fix BashShell banner reading error in slow shells by adding banner_timeout
  keyword argument

- Fix hanging of the start in case in case BashShell value of tty_echo is True
  while in reality the terminal echo is off