### PR TITLE
Avoid literal str when setting prompt in BashShell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@
 CHANGES
 =======
 
+1.3.2
+-----
+
+- Change prompt setting in BashShell so that the prompt is not literally
+  shown in command history, otherwise listing command history could lead
+  to incorrect match when reading command output until prompt is found.
+
 1.3.1
 -----
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019-2020, Nokia'
 
-VERSION = '1.3.1'
+VERSION = '1.3.2'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/bashshell.py
+++ b/src/crl/interactivesessions/shells/bashshell.py
@@ -132,7 +132,11 @@ class BashShell(AutoCompletableShell):
     def set_prompt(self):
         if self.set_rand_promt:
             self._send_input_line("unset PROMPT_COMMAND")
-            self._send_input_line("export PS1={0}".format(self._prompt))
+            # Split the prompt and use bash concatenate to avoid literal prompt
+            # in command history. Prompt is output of uuid.uuid4() with length 36
+            # so split at 3 can be safely done.
+            prompt_cmd = "export PS1='{}''{}'".format(self._prompt[:3], self._prompt[3:])
+            self._send_input_line(prompt_cmd)
 
     def _detect_bash_prompt(self):
         """Detect current bash prompt and make sure terminal

--- a/tests/shells/conftest.py
+++ b/tests/shells/conftest.py
@@ -88,6 +88,7 @@ def terminate_msgpythonshell(retry_shellcontext, normal_pythonterminal):
         finally:
             normal_pythonterminal.terminate()
 
+
 # pylint: disable=unused-argument
 @pytest.fixture
 def retry_shellcontext(mock_strcomm, simple_retry_shellcontext):

--- a/tests/test_terminalpools.py
+++ b/tests/test_terminalpools.py
@@ -135,9 +135,9 @@ class FakeShuffle(object):
         self.shuffle_max = shuffle_max
         self.count = 0
 
-    def shuffle(self, l):
-        tofront = l.pop(self.count % self.shuffle_max)
-        l.insert(0, tofront)
+    def shuffle(self, li):
+        tofront = li.pop(self.count % self.shuffle_max)
+        li.insert(0, tofront)
         self.count += 1
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,7 @@ basepython = python3.7
 changedir = {toxinidir}
 deps =
     {[testenv:docs]deps}
-
+    check-manifest<0.42
 commands =
     crl test --no-virtualenv {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands = pylint {posargs: --rcfile={toxinidir}/.pylintrc \
 [testenv:pylint37]
 basepython = python3.7
 deps =
-    pylint
+    pylint == 2.5
     {[base3]deps}
 commands = {[testenv:pylint27]commands}
 


### PR DESCRIPTION
The command used to set prompt in BashShell contained the prompt
as a literal string "export PS1=newprompt", causing false match
when executing commands like 'history'.

To avoid that the prompt is set by adding extra quotation marks
in the middle, like "export PS1='new''prompt'".

Fixes #59