### PR TITLE
Fix tox test errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ docker = test
 basepython = python3.7
 deps =
     {[base3]deps}
-commandd = {posargs:py.test --doctest-modules \
+commands = {posargs:py.test --doctest-modules \
            {envsitepackagesdir}/crl/interactivesessions/shells/remotemodules/ \
            {envsitepackagesdir}/crl/interactivesessions/shells/shell.py \
            {envsitepackagesdir}/crl/interactivesessions/shells/bashshell.py \


### PR DESCRIPTION
Tox tests for doctest, py36 and py37 environments fail for latest version on master, this PR intends to fix those.