### PR TITLE
Fix RaPythonShell in Python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@
 CHANGES
 =======
 
+1.4.0b4
+-------
+
+- Fix RawPythonShell problem with Python 3.12 by removing superfluous output
+  from the terminal caused the new return values from termios.tcsetattr and/or
+  tty.setraw.
+
 1.4.0b3
 -------
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019-2023, Nokia'
 
-VERSION = '1.4.0b3'
+VERSION = '1.4.0b4'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/rawpythonshell.py
+++ b/src/crl/interactivesessions/shells/rawpythonshell.py
@@ -14,10 +14,10 @@ class RawPythonShell(PythonShellBase):
         '_orig_inattrs = termios.tcgetattr(_fdin)',
         '_new_inattrs = termios.tcgetattr(_fdin)',
         '_new_inattrs[3] = _new_inattrs[3] & ~termios.ECHO',
-        'termios.tcsetattr(_fdin, termios.TCSADRAIN, _new_inattrs)']
+        '_tmp_ret = termios.tcsetattr(_fdin, termios.TCSADRAIN, _new_inattrs)']
 
     setup_cmds = _setup_cmds_before_echo_off + [
-        'tty.setraw(_fdin)',
+        '_tmp_ret = tty.setraw(_fdin)',
         "'endofsetup'"]
     teardown_cmd = 'termios.tcsetattr(_fdin, termios.TCSADRAIN, _orig_inattrs)'
 


### PR DESCRIPTION
Fix RawPythonShell problem with Python 3.12 by removing superfluous output from the terminal caused the new return values from termios.tcsetattr and/or tty.setraw.