### PR TITLE
Fix overflow in Python server write

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@
 CHANGES
 =======
 
+1.4.0b5
+-------
+
+- Fix overflow in Python server write by sending ACK messages for each chunk if
+  more than one chunk in the message.  Moreover, reduce the chunk size to 2 KB
+  from 4 KB and remove the imp module from default modules of the terminal as
+  it is removed from Python 3.12.
+
 1.4.0b4
 -------
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019-2023, Nokia'
 
-VERSION = '1.4.0b4'
+VERSION = '1.4.0b5'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/runnerterminal.py
+++ b/src/crl/interactivesessions/runnerterminal.py
@@ -132,7 +132,7 @@ class RunnerTerminal(object):
         args='{response_id}, timeout={timeout}')
 
     # list of libraries to be imported on the remote end during setup phase
-    _IMPORTS = ['pickle', 'imp', 'base64', 'os']
+    _IMPORTS = ['pickle', 'base64', 'os']
 
     # OPTIONS FOR CONFIGURING SUBCLASS BEHAVIOR
     # path to retrieve the remote handler module from

--- a/src/crl/interactivesessions/shells/remotemodules/servercomm.py
+++ b/src/crl/interactivesessions/shells/remotemodules/servercomm.py
@@ -15,12 +15,12 @@ __copyright__ = 'Copyright (C) 2019, Nokia'
 CHILD_MODULES = [chunkcomm, compatibility]
 
 
-class ServerComm(chunkcomm.ChunkWriterBase, chunkcomm.ChunkReaderBase):
+class ServerComm(chunkcomm.ChunkAckBase):
 
     _sleep_in_broken_systems = 0.00005
 
     def __init__(self, infd, outfile):
-        chunkcomm.ChunkReaderBase.__init__(self)
+        chunkcomm.ChunkAckBase.__init__(self)
         self.infd = infd
         self.outfile = outfile
         self._msgcaches = None
@@ -50,7 +50,8 @@ class ServerComm(chunkcomm.ChunkWriterBase, chunkcomm.ChunkReaderBase):
     def _read(self, n):
         while True:
             r, _, _ = select.select([self.infd], [], [], *self._msgcaches.timeout_args)
-            self._msgcaches.send_expired()
+            if not self._chunk_ack_reading:
+                self._msgcaches.send_expired()
             if r:
                 try:
                     return self._read_sleep_if_needed(n)

--- a/src/crl/interactivesessions/shells/terminalclient.py
+++ b/src/crl/interactivesessions/shells/terminalclient.py
@@ -5,9 +5,7 @@ import pexpect
 from monotonic import monotonic
 from crl.interactivesessions.shells.shell import TimeoutError
 from .remotemodules.msgmanager import MsgManagerBase
-from .remotemodules.chunkcomm import (
-    ChunkReaderBase,
-    ChunkWriterBase)
+from .remotemodules.chunkcomm import ChunkAckBase
 from .remotemodules.msgs import Ack
 
 
@@ -68,7 +66,6 @@ class TerminalClient(MsgManagerBase):
         for received_msg in self._received_msgs_for_msg(msg):
             if isinstance(received_msg, Ack):
                 return self._try_to_receive_until_reply(msg, timeout)
-
             return received_msg
 
         return self._final_try_to_receive_until_reply(msg, timeout)
@@ -78,7 +75,6 @@ class TerminalClient(MsgManagerBase):
             self.send(msg)
             try:
                 yield self._receive_ack_or_reply(msg, t)
-
             except (TerminalClientError, TimerTimeout) as e:
                 LOGGER.debug('No reply yet for message uid %s: %s', msg.uid, e)
 
@@ -156,9 +152,9 @@ class TerminalClient(MsgManagerBase):
                 raise
 
 
-class TerminalComm(ChunkReaderBase, ChunkWriterBase):
+class TerminalComm(ChunkAckBase):
     def __init__(self, terminal):
-        ChunkReaderBase.__init__(self)
+        ChunkAckBase.__init__(self)
         self._terminal = terminal
         self._timeout = -1
 

--- a/tests/shells/remotemodules/test_chunkcomm.py
+++ b/tests/shells/remotemodules/test_chunkcomm.py
@@ -18,7 +18,7 @@ from crl.interactivesessions.shells.remotemodules.compatibility import to_bytes
 __copyright__ = 'Copyright (C) 2019, Nokia'
 
 EXPECTED_TOKEN_LEN = 20
-EXPECTED_LEN_WIDTH = len(str(CHUNKSIZE))
+EXPECTED_HDR_LEN = 8
 LOGGER = logging.getLogger(__name__)
 
 
@@ -104,8 +104,8 @@ class DataRubbishWriter(MiddleWriterBase):
 
     """
     def _get_rubbish_start(self, s):
-        data_len = len(s) - 3 * EXPECTED_TOKEN_LEN - EXPECTED_LEN_WIDTH
-        return 2 * EXPECTED_TOKEN_LEN + EXPECTED_LEN_WIDTH + int(
+        data_len = len(s) - 3 * EXPECTED_TOKEN_LEN - EXPECTED_HDR_LEN
+        return 2 * EXPECTED_TOKEN_LEN + EXPECTED_HDR_LEN + int(
             data_len * self._clean_portion)
 
 
@@ -116,7 +116,7 @@ class LenRubbishWriter(MiddleWriterBase):
         {token}{data_len_start}{rubbish}{data_len_end}{token}{data}{token}
     """
     def _get_rubbish_start(self, s):  # pylint: disable=unused-argument
-        return EXPECTED_TOKEN_LEN + int(EXPECTED_LEN_WIDTH * self._clean_portion)
+        return EXPECTED_TOKEN_LEN + int(EXPECTED_HDR_LEN * self._clean_portion)
 
 
 class ExampleChunkReader(ChunkReaderBase):

--- a/tests/shells/test_pythonshell.py
+++ b/tests/shells/test_pythonshell.py
@@ -128,13 +128,15 @@ def test_start_rawpythonshell(mockrawpythonshell):
     mockrawpythonshell.start()
 
     first_read = mock.call(timeout=30, suppress_timeout=False)
-    set_echo_off_read = mock.call(timeout=10, suppress_timeout=False)
+    set_echo_off_reads = [mock.call(timeout=10, suppress_timeout=False)
+                          for _ in range(2)]
 
-    expected_reads = [first_read, set_echo_off_read]
+    expected_reads = [first_read] + set_echo_off_reads
+    print(mockrawpythonshell.mock_read_until_prompt.mock_calls)
     assert mockrawpythonshell.mock_read_until_prompt.mock_calls == expected_reads
 
     assert mockrawpythonshell.mock_terminal.sendline.mock_calls == [
-        mock.call(cmd) for cmd in mockrawpythonshell.setup_cmds]
+        mock.call(cmd) for cmd in mockrawpythonshell.setup_cmds + ["'ready'"]]
 
 
 def test_start_rawpythonshell_raises(mockrawpythonshell):

--- a/tests/test_runnerterminal.py
+++ b/tests/test_runnerterminal.py
@@ -132,7 +132,7 @@ def test_initialize_import_libraries(runnerterminal,
     cs = mock_session.get_session.return_value.current_shell.return_value
 
     assert cs.exec_command.mock_calls[0] == mock.call(
-        'import pickle, imp, base64, os', timeout=-1)
+        'import pickle, base64, os', timeout=-1)
 
 
 def test_close_session(runnerterminal,


### PR DESCRIPTION
Send ACK messages for each chunk if more than one chunk in the message. Moreover, reduce the chunk size to 2 KB from 4 KB and remove the imp module from default modules of the terminal as it is removed from Python 3.12.