### PR TITLE
Fix MsgPythonShell initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@
 CHANGES
 =======
 
+1.4.0b7
+-------
+
+- Fix MsgPythonShell initialization. In some terminals the initialization is
+  not working or is flaky because the size of the modules data sent is too
+  large causing corruption to Python terminal. The fix is to split the modules
+  into smaller chunks instead prior compiling those.
+
 1.4.0b6
 -------
 

--- a/src/crl/interactivesessions/_version.py
+++ b/src/crl/interactivesessions/_version.py
@@ -1,6 +1,6 @@
 __copyright__ = 'Copyright (C) 2019-2023, Nokia'
 
-VERSION = '1.4.0b6'
+VERSION = '1.4.0b7'
 GITHASH = ''
 
 

--- a/src/crl/interactivesessions/shells/modules.py
+++ b/src/crl/interactivesessions/shells/modules.py
@@ -7,12 +7,25 @@ Note:
       run actual commands in the remote end.
 """
 
+import hashlib
 import os
 import itertools
-from .termserialization import serialize_from_file
+from .termserialization import b64_pickled_source_from_file
 
 
 __copyright__ = 'Copyright (C) 2019, Nokia'
+
+
+def _path_bytes_for_fingerprint(path):
+    """Bytes form of *path* for hashing; works on Python 2 and 3."""
+    if isinstance(path, bytes):
+        return path
+    try:
+        return os.fsencode(path)
+    except AttributeError:
+        if hasattr(path, 'encode'):
+            return path.encode('utf-8', 'replace')
+        return path
 
 
 class MainModule(object):
@@ -22,10 +35,15 @@ class MainModule(object):
     command for exec itself.
     """
     _cmd_treshold_len = 5000
+    #: Max characters per ``+=`` fragment when building the pickled source on the
+    #: remote side (limits single terminal lines; 0 or negative means no limit).
+    _compile_cmd_chunk_size = 1024
 
-    def __init__(self, module):
+    def __init__(self, module, compile_cmd_chunk_size=None):
         self.module = module
         self._module_vars = {}
+        if compile_cmd_chunk_size is not None:
+            self._compile_cmd_chunk_size = compile_cmd_chunk_size
 
     @property
     def module_var(self):
@@ -108,15 +126,35 @@ class MainModule(object):
             pass
 
     def _exec_cmd_gen(self):
-        yield 'exec({compile_cmd}, {module_var}.__dict__)'.format(
-            compile_cmd=self._compile_cmd,
+        for cmd in self._reconstruct_pickled_source_cmds_gen():
+            yield cmd
+        compile_expr = (
+            "compile(pickle.loads(base64.b64decode({var})), filename={fname!r}, "
+            "mode='exec')").format(
+                var=self._compile_src_temp_var,
+                fname=os.path.basename(self.path))
+        yield 'exec({compile_expr}, {module_var}.__dict__)'.format(
+            compile_expr=compile_expr,
             module_var=self.module_var)
 
     @property
-    def _compile_cmd(self):
-        return ("compile({serialized}, filename='{basename}', "
-                "mode='exec')".format(serialized=serialize_from_file(self.path),
-                                      basename=os.path.basename(self.path)))
+    def _compile_src_temp_var(self):
+        """Stable remote name for the reconstructed base64 pickle payload."""
+        digest = hashlib.md5(_path_bytes_for_fingerprint(self.path)).hexdigest()[:16]
+        return '__crl_isess_src_{}'.format(digest)
+
+    def _reconstruct_pickled_source_cmds_gen(self):
+        """Emit ``temp = ''`` and ``temp += '...'`` lines bounded by chunk size."""
+        b64_payload = b64_pickled_source_from_file(self.path)
+        chunk_size = self._compile_cmd_chunk_size
+        var = self._compile_src_temp_var
+        if chunk_size is None or chunk_size <= 0:
+            yield "{} = {}".format(var, repr(b64_payload))
+            return
+        yield "{} = ''".format(var)
+        for i in range(0, len(b64_payload), chunk_size):
+            piece = b64_payload[i:i + chunk_size]
+            yield "{} += {}".format(var, repr(piece))
 
 
 class ChildModule(MainModule):

--- a/src/crl/interactivesessions/shells/termserialization.py
+++ b/src/crl/interactivesessions/shells/termserialization.py
@@ -9,6 +9,14 @@ def serialize_from_file(path):
     return serialize(_read_content(path))
 
 
+def b64_pickled_source_from_file(path):
+    """Return ASCII base64 of pickled file text (same payload as :func:`serialize`)."""
+    raw = base64.b64encode(pickle.dumps(_read_content(path), protocol=0))
+    if isinstance(raw, bytes):
+        return raw.decode('ascii')
+    return raw
+
+
 def serialize(s):
     return "pickle.loads(base64.b64decode({!r}))".format(
         base64.b64encode(pickle.dumps(s, protocol=0)))

--- a/tests/shells/test_modules.py
+++ b/tests/shells/test_modules.py
@@ -1,6 +1,10 @@
+import ast
+
 from crl.interactivesessions.shells.modules import MainModule
 from crl.interactivesessions.shells.remotemodules.pythoncmdline import (
     PythonCmdline)
+from crl.interactivesessions.shells.termserialization import (
+    b64_pickled_source_from_file)
 
 from .exampleremotemodules import mainexample
 
@@ -27,3 +31,41 @@ def test_module_descendants():
         p.exec_command(cmd)
     assert p.exec_command("{mod}.call_descendants()".format(
         mod=main.module_var)) == mainexample.call_descendants()
+
+
+def test_module_descendants_tiny_compile_chunks():
+    """Chunked source reconstruction must match single-shot behavior."""
+    main = MainModule(mainexample, compile_cmd_chunk_size=24)
+    p = PythonCmdline()
+    for cmd in main.cmds_gen():
+        p.exec_command(cmd)
+    assert p.exec_command("{mod}.call_descendants()".format(
+        mod=main.module_var)) == mainexample.call_descendants()
+
+
+def test_compile_reconstruct_commands_respect_chunk_size():
+    """Each ``+=`` fragment must be at most *compile_cmd_chunk_size* characters."""
+    chunk_size = 37
+    main = MainModule(mainexample, compile_cmd_chunk_size=chunk_size)
+    var = main._compile_src_temp_var
+    expected_b64 = b64_pickled_source_from_file(main.path)
+    lines = list(main._reconstruct_pickled_source_cmds_gen())
+    assert lines[0] == "{} = ''".format(var)
+    rebuilt = ''
+    for line in lines[1:]:
+        prefix = '{} += '.format(var)
+        assert line.startswith(prefix)
+        piece = ast.literal_eval(line[len(prefix):])
+        assert len(piece) <= chunk_size
+        rebuilt += piece
+    assert rebuilt == expected_b64
+
+
+def test_compile_reconstruct_unlimited_uses_single_assignment():
+    """``compile_cmd_chunk_size <= 0`` must emit one assignment with the full payload."""
+    main = MainModule(mainexample, compile_cmd_chunk_size=0)
+    var = main._compile_src_temp_var
+    expected_b64 = b64_pickled_source_from_file(main.path)
+    lines = list(main._reconstruct_pickled_source_cmds_gen())
+    assert len(lines) == 1
+    assert lines[0] == '{} = {}'.format(var, repr(expected_b64))

--- a/tests/shells/test_termserialization.py
+++ b/tests/shells/test_termserialization.py
@@ -1,8 +1,9 @@
 import os
-import pickle  # pylint: disable=unused-import; # noqa: F401
-import base64  # pylint: disable=unused-import; # noqa: F401
+import pickle
+import base64
 import pytest
 from crl.interactivesessions.shells.termserialization import (
+    b64_pickled_source_from_file,
     serialize_from_file,
     serialize)
 
@@ -22,6 +23,13 @@ def tmpfile_factory(tmpdir):
 def test_serialize_from_file(tmpfile_factory):
     content = 'content'
     assert eval(serialize_from_file(tmpfile_factory(content))) == content
+
+
+def test_b64_pickled_source_from_file(tmpfile_factory):
+    content = 'content'
+    path = tmpfile_factory(content)
+    assert pickle.loads(base64.b64decode(
+        b64_pickled_source_from_file(path))) == content
 
 
 def test_serialize():


### PR DESCRIPTION
Fix MsgPythonShell initialization. In some terminals the initialization is not working or is flaky because the size of the modules data sent is too large causing corruption to Python terminal. The fix is to split the modules into smaller chunks instead prior compiling those.